### PR TITLE
jsdom upgrade

### DIFF
--- a/jquery-detached/package.json
+++ b/jquery-detached/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "devDependencies": {
     "gulp": "^3.9.0",
-    "jsdom": "3.1.2",
+    "jsdom": "7.0.2",
     "jenkins-js-builder": "0.0.19"
   },
   "dependencies": {


### PR DESCRIPTION
On my amd64 linux I was hitting the problem described in
https://github.com/brianmcd/contextify/issues/179 during the build.

contextify is a transitive dependency of jsdom.

In consultation with Tom, bumping up the version of jsdom was enough to
get the build to succeed.