### PR TITLE
Update momentjs 2.19.3

### DIFF
--- a/momentjs/package.json
+++ b/momentjs/package.json
@@ -14,6 +14,6 @@
   },
   "dependencies": {
     "jenkins-js-modules": "1.5.4",
-    "moment": "^2.10.3"
+    "moment": "^2.19.3"
   }
 }

--- a/momentjs/pom.xml
+++ b/momentjs/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>momentjs</artifactId>
-    <version>2.0.0-alphabet</version>
     <packaging>hpi</packaging>
 
     <name>JavaScript GUI Lib: Moment.js bundle plugin</name>

--- a/momentjs/pom.xml
+++ b/momentjs/pom.xml
@@ -11,6 +11,7 @@
     </parent>
 
     <artifactId>momentjs</artifactId>
+    <version>2.0.0-alphabet</version>
     <packaging>hpi</packaging>
 
     <name>JavaScript GUI Lib: Moment.js bundle plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.jenkins-ci.ui</groupId>
     <artifactId>jenkins-js-libs</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Lib Bundle: Parent POM</name>


### PR DESCRIPTION
momentjs <2.19.3 has these CVEs: [cvedetails](https://www.cvedetails.com/vulnerability-list/vendor_id-16043/product_id-35644/opdos-1/Moment-Project-Moment.html
)

Even-though this is no longer maintained, it is still a dependency for many other plugins. So it was easiest to create a fix here and submit.

Only change was bumping the nodejs version. Builds fine with JDK 11 and was successfully deployed to a local Jenkins with latest LTS Core.


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- --Link to relevant issues in GitHub or Jira
- --Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
