### PR TITLE
Fix poms, modernize

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,10 @@ that __can__ be externalized via the [easy/recommended externalization process].
 
 > Also see __[sample plugins](https://github.com/jenkinsci/js-samples)__. 
 
+# Development
+
+This repository needs to be cloned with the `git` option `core.symlinks` set to `true` to create a symbolic link for `ace-editor/src/test/webroot/jenkins/plugin/ace-editor`.
+Otherwise, the tests of `ace-editor` will fail.
+
 [jenkins-js-modules]: https://github.com/tfennelly/jenkins-js-modules
 [easy/recommended externalization process]: https://github.com/jenkinsci/js-samples/blob/master/step-04-externalize-libs/HOW-IT-WORKS.md#configure-node-build-to-externalize-dependencies

--- a/ace-editor/pom.xml
+++ b/ace-editor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.ui</groupId>
         <artifactId>jenkins-js-libs</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.ui</groupId>
         <artifactId>jenkins-js-libs</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/handlebars/pom.xml
+++ b/handlebars/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.ui</groupId>
         <artifactId>jenkins-js-libs</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jquery-detached/pom.xml
+++ b/jquery-detached/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.ui</groupId>
         <artifactId>jenkins-js-libs</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/momentjs/pom.xml
+++ b/momentjs/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.ui</groupId>
         <artifactId>jenkins-js-libs</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/numeraljs/pom.xml
+++ b/numeraljs/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.ui</groupId>
         <artifactId>jenkins-js-libs</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.16</version>
+        <version>4.54</version>
         <relativePath/>
     </parent>
 
@@ -27,7 +27,6 @@
     </modules>
 
     <properties>
-        <java.level>8</java.level>
         <node.version>10.16.3</node.version>
         <npm.version>6.12.0</npm.version>
     </properties>


### PR DESCRIPTION
## Motivation

The plugins in this repository stand out as being by far the least actively maintained among the top 100 plugins by popularity.

They're by far the least recently released (March 2016) and have by far the oldest core dependency (1.580.1). Since `ace-editor` is a dependency of `workflow-cps`, there's no modern Pipeline-based Jenkins possible without it, making removal of unused implied dependencies cumbersome to impossible.

## PR Content

This fixes the pom references broken since https://github.com/jenkinsci/js-libs/commit/2048280a7b9bb56ac33c7d170be7d891a7cbaaec, and updates to the newest plugin parent POM.

As a result, this now depends on Jenkins 2.361 and requires Java 11 to build.

Also documented the `core.symlinks` requirement for Git.

## Testing

Did some minimal testing of `ace-editor` via `workflow-cps`. While the generated JS output is slightly different (probably from an earlier, unreleased change), basic features (error annotation, collapsing blocks, syntax highlighting) worked.
<img width="2161" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/214580265-290c31b3-5113-444d-8aec-2c7009eac229.png">
